### PR TITLE
Revert "Sync26 meta-release Declaration"

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -8,10 +8,10 @@
 repository:
   # How this repository participates in CAMARA releases
   # Options: independent (default) | meta-release
-  release_track: meta-release
+  release_track: independent
 
   # Uncomment and set when planning a meta-release participation:
-  meta_release: Sync26
+  # meta_release: Sync26
 
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)


### PR DESCRIPTION
This PR reverts camaraproject/NetworkInsights#85. The PR wrongly declared the independent public release r1.3 as part of Sync26. There won't be public releases for Sync26 before September ... the next milestone for Sync26 is M3 with the release candidate.

Instead "re-declaring" the already public release with v0.1.0 start a new release cycle for Sync26, with r2.1, target version 0.2.0 and target status rc for the M3 milestone. Before creating this release address the remaining issues which were deferred to be addressed after 0.1.0.